### PR TITLE
fix: python3 socket interaction expects bytes

### DIFF
--- a/quagga.py
+++ b/quagga.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import json
 import socket
 import collectd
-
+import sys
 
 class Quagga(object):
 
@@ -63,11 +63,18 @@ class Quagga(object):
 
             # Send the query
             collectd.debug("query: send {}".format(query))
-            sock.send("{}\0".format(query))
+            if sys.version_info > (3, 0):
+                sock.sendall(("{}\0".format(query)).encode())
+            else:
+                sock.sendall("{}\0".format(query))
+
 
             data = []
             while True:
-                more = sock.recv(1024)
+                if sys.version_info > (3, 0):
+                    more = sock.recv(1024).decode()
+                else:
+                    more = sock.recv(1024)
                 if not more:
                     break
                 collectd.debug("query: got {}".format(more.rstrip('\x00')))


### PR DESCRIPTION
Python3 socket sendall() and recv() expect bytes rather than
string. Collectd quagga module was failing on Focal hypervisors
with:

```
  File "/usr/share/collectd/python/quagga.py", line 66,
     in _query\n    sock.send("{}\0".format(query))"
  TypeError: a bytes-like object is required, not 'str'
```

Let's correctly send/receive bytes to Quagga/FRR socket and restore
respective metrics.

Related to [ch24481]

### Testing 

Monkey patched `/usr/share/collectd/python/quagga.py` on `virt-hv-pp058.gv2.p.exoscale.net` and verified collectd emits metrics:
```
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin quagga (instance bgp_evpn) type quagga_bgp_neighbor (instance 172.20.144.141): All data s
ources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"quagga","plugin_instanc
e":"bgp_evpn","type":"quagga_bgp_neighbor","type_instance":"172.20.144.141","severity":"ok","level":"info","@timestamp":"2021-01-19T16:56:09Z"}
```

Also visible in riemann.